### PR TITLE
Only put back the connection to pool if got no error.

### DIFF
--- a/redis.go
+++ b/redis.go
@@ -331,7 +331,6 @@ func (r *Redis) ExecuteCommand(args ...interface{}) (*Reply, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer func() { r.pool.Put(c) }()
 	if err := c.SendCommand(args...); err != nil {
 		if err != io.EOF {
 			return nil, err
@@ -356,7 +355,10 @@ func (r *Redis) ExecuteCommand(args ...interface{}) (*Reply, error) {
 		if err = c.SendCommand(args...); err != nil {
 			return nil, err
 		}
-		return c.RecvReply()
+		rp, err = c.RecvReply()
+	}
+	if err == nil {
+		defer func() { r.pool.Put(c) }()
 	}
 	return rp, err
 }

--- a/redis.go
+++ b/redis.go
@@ -358,7 +358,7 @@ func (r *Redis) ExecuteCommand(args ...interface{}) (*Reply, error) {
 		rp, err = c.RecvReply()
 	}
 	if err == nil {
-		defer func() { r.pool.Put(c) }()
+		r.pool.Put(c)
 	}
 	return rp, err
 }


### PR DESCRIPTION
When error happens, instead of put back the good connection, this line of code below will put back the bad one.
https://github.com/xuyu/goredis/blob/master/redis.go#L334

Because `c` variable being used in `r.pool.Put(c)` is the first connection we got from pool.
i.e. from this line

```
func (r *Redis) ExecuteCommand(args ...interface{}) (*Reply, error) {
    c, err := r.pool.Get()
```

This PR fix this by only put back the good one to the pool.
